### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
-numpy==1.21.5
-pandas==1.3.5
-pyalsaaudio==0.9.0
+numpy==1.23.0
+pandas==2.1.1
+pyalsaaudio==0.10.0
 pyparsing
 python-dateutil
 six


### PR DESCRIPTION
Errors concerning numpy when new OS from RPi is installed. I believe these are the latest versions of numpy, pandas, and pyalsaaudio for Python 3.9.2 
numpy 1.23.0
pandas 2.1.1
pyalsaaudio 0.10.0