### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
-numpy>=1.21.5
-pandas>=1.3.5
-pyalsaaudio>=0.9.0
+numpy==1.23.0
+pandas==2.1.1
+pyalsaaudio==0.10.0
 pyparsing
 python-dateutil
 six


### PR DESCRIPTION
Error messages occur when installing supersid with the latest version of the RPi OS.
I believe the versions of numpy, pandas, and pyalsaaudio have to be updated in requirements.txt
These are the versions that I found when searching.
numpy 1.23.0, pandas 2.1.1, pyalsaaudio 0.10.0  
These work with the fresh install that I did.
New versions did not update until I changed >= to == in requirements.txt
The new RPi OS shows python as version 3.9.2
